### PR TITLE
Update api.py for take_profit and trailing_stop

### DIFF
--- a/ftx/api.py
+++ b/ftx/api.py
@@ -156,8 +156,8 @@ class FtxClient:
 
         return self._post(f'conditional_orders',
                           {'market': market, 'side': side, 'triggerPrice': trigger_price,
-                           'size': size, 'reduceOnly': reduce_only, 'type': 'stop',
-                           'cancelLimitOnTrigger': cancel, 'orderPrice': limit_price})
+                           'size': size, 'reduceOnly': reduce_only, 'type': type,
+                           'cancelLimitOnTrigger': cancel, 'orderPrice': limit_price, 'trailValue': trail_value})
 
     @authentication_required
     def cancel_order(self, order_id: str) -> dict:


### PR DESCRIPTION
edited def place_conditional_order

Line 159. Changed:
"'type': stop" to "'type': type" to allow use of stop, take_profit and trailing_stop types.

Line 160. Added:
"'trailValue': trail_value" to add a trail_value when entering a trailing_stop type order.