### PR TITLE
Adds basic support for the FTX websockets API

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,32 @@ Orders can be modified by providing the original order ID.
 An order can be canceled given the order ID:
 
     client.cancel_order(9596912).result()
+
+
+## WebSocket usage
+Websocket can be used to subscribe to realtime updates on several channels as described in the [FTX websocket documentation](https://docs.ftx.com/#public-channels).
+
+The `websocket` property on the FtxClient can be used to connect a websocket with the same credentials as the FtxClient object.
+To connect using different credentials instantiate a new websocket client using the `FtxWebSocketClient` constructor.
+
+
+**Example subscription to trade channel**
+```python
+async def main():
+    ftx = FtxClient(ws_queue_size=16)
+    # connect the websocket
+    await ftx.websocket.connect()
+
+    # subscribe to a channel
+    await ftx.websocket.subscribe('trades', 'BTC-PERP')
+
+    while ftx.websocket.connected:
+        # block and wait for next message
+        msg = await ftx.websocket.recv()
+        if msg and 'channel' in msg and msg['channel'] == 'trades':
+            if 'data' in msg:
+                # print the trade price
+                print('price:', msg['data'][0]['price'])
+
+    await ftx.websocket.disconnect()
+```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The next thing you need to do is import the library and get an instance of the c
     import ftx
     client = ftx.FtxClient()
 
-### Get ordedrbook
+### Get orderbook
 
 Get the orderbook levels of bid/ask:
 
@@ -34,7 +34,7 @@ Get the orderbook levels of bid/ask:
     >>> result['bids']
     [[11860.5, 0.1]]
 
-### Market's Instrument data
+### Market's instrument data
 
 The API supports fetching full data for one or multiple markets.
 

--- a/example/websocket.py
+++ b/example/websocket.py
@@ -5,13 +5,20 @@ from ftx import FtxClient
 
 async def main():
     ftx = FtxClient()
+    # connect the websocket
     await ftx.websocket.connect()
 
     first_market = ftx.get_markets()[0]
+    # subscribe to the trades channel of first available market
     await ftx.websocket.subscribe('trades', first_market['name'])
 
     while ftx.websocket.connected:
-        print(await ftx.websocket.recv())
+        # block and wait for next message
+        msg = await ftx.websocket.recv()
+        if 'channel' in msg and msg['channel'] == 'trades':
+            if 'data' in msg:
+                # print trade
+                print(msg['market'], msg['data'][0]['side'], msg['data'][0]['size'])
 
 
 if __name__ == '__main__':

--- a/example/websocket.py
+++ b/example/websocket.py
@@ -5,13 +5,13 @@ from ftx import FtxClient
 
 async def main():
     ftx = FtxClient()
-    await ftx.websockets.connect()
+    await ftx.websocket.connect()
 
     first_market = ftx.get_markets()[0]
-    await ftx.websockets.subscribe('trades', first_market['name'])
+    await ftx.websocket.subscribe('trades', first_market['name'])
 
-    while ftx.websockets.connected:
-        print(await ftx.websockets.recv())
+    while ftx.websocket.connected:
+        print(await ftx.websocket.recv())
 
 
 if __name__ == '__main__':

--- a/example/websocket.py
+++ b/example/websocket.py
@@ -1,0 +1,18 @@
+import asyncio
+
+from ftx import FtxClient
+
+
+async def main():
+    ftx = FtxClient()
+    await ftx.websockets.connect()
+
+    first_market = ftx.get_markets()[0]
+    await ftx.websockets.subscribe('trades', first_market['name'])
+
+    while ftx.websockets.connected:
+        print(await ftx.websockets.recv())
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/example/websocket.py
+++ b/example/websocket.py
@@ -4,24 +4,22 @@ from ftx import FtxClient
 
 
 async def main():
-    ftx = FtxClient(ws_max_queue_size=16)
+    ftx = FtxClient(ws_queue_size=16)
     # connect the websocket
     await ftx.websocket.connect()
 
-    # subscribe to the trades channel
+    # subscribe to a channel
     await ftx.websocket.subscribe('trades', 'BTC-PERP')
 
-    trades = []
-    while ftx.websocket.connected and len(trades) < 10:
+    while ftx.websocket.connected:
         # block and wait for next message
         msg = await ftx.websocket.recv()
         if msg and 'channel' in msg and msg['channel'] == 'trades':
             if 'data' in msg:
-                # print trade
-                print(ftx.websocket.messages_dropped, 'messages dropped, price:', msg['data'][0]['price'])
+                # print the trade price
+                print('price:', msg['data'][0]['price'])
 
-    if ftx.websocket.connected:
-        await ftx.websocket.disconnect()
+    await ftx.websocket.disconnect()
 
 
 if __name__ == '__main__':

--- a/example/websocket.py
+++ b/example/websocket.py
@@ -15,7 +15,7 @@ async def main():
     while ftx.websocket.connected and len(trades) < 10:
         # block and wait for next message
         msg = await ftx.websocket.recv()
-        if 'channel' in msg and msg['channel'] == 'trades':
+        if msg and 'channel' in msg and msg['channel'] == 'trades':
             if 'data' in msg:
                 # print trade
                 print(ftx.websocket.messages_dropped, 'messages dropped, price:', msg['data'][0]['price'])

--- a/ftx/api.py
+++ b/ftx/api.py
@@ -16,6 +16,7 @@ class FtxClient:
         api_key: Optional[str] = None,
         api_secret: Optional[str] = None,
         subaccount_name: Optional[str] = None,
+        ws_max_queue_size: int = 1024
     ) -> None:
         self._session = Session()
         self._base_url = base_url
@@ -23,6 +24,7 @@ class FtxClient:
         self._api_secret = api_secret
         self._subaccount_name = subaccount_name
         self._ws_client = None
+        self._ws_max_queue_size = ws_max_queue_size
 
     def _get(self, path: str, params: Optional[Dict[str, Any]] = None) -> Any:
         return self._request('GET', path, params=params)
@@ -70,7 +72,8 @@ class FtxClient:
             self._ws_client = FtxWebSocketClient(
                 api_key=self._api_key,
                 api_secret=self._api_secret,
-                subaccount_name=self._subaccount_name
+                subaccount_name=self._subaccount_name,
+                max_queue_size=self._ws_max_queue_size
             )
         return self._ws_client
 

--- a/ftx/api.py
+++ b/ftx/api.py
@@ -16,7 +16,7 @@ class FtxClient:
         api_key: Optional[str] = None,
         api_secret: Optional[str] = None,
         subaccount_name: Optional[str] = None,
-        ws_max_queue_size: int = 1024
+        ws_queue_size: int = 1024
     ) -> None:
         self._session = Session()
         self._base_url = base_url
@@ -24,7 +24,7 @@ class FtxClient:
         self._api_secret = api_secret
         self._subaccount_name = subaccount_name
         self._ws_client = None
-        self._ws_max_queue_size = ws_max_queue_size
+        self._ws_queue_size = ws_queue_size
 
     def _get(self, path: str, params: Optional[Dict[str, Any]] = None) -> Any:
         return self._request('GET', path, params=params)
@@ -73,7 +73,7 @@ class FtxClient:
                 api_key=self._api_key,
                 api_secret=self._api_secret,
                 subaccount_name=self._subaccount_name,
-                max_queue_size=self._ws_max_queue_size
+                queue_size=self._ws_queue_size
             )
         return self._ws_client
 

--- a/ftx/api.py
+++ b/ftx/api.py
@@ -60,7 +60,7 @@ class FtxClient:
                 self._subaccount_name)
 
     @property
-    def websockets(self) -> FtxWebSocketClient:
+    def websocket(self) -> FtxWebSocketClient:
         """
         Lazy FtxWebSocketClient with the same credentials
 

--- a/ftx/api.py
+++ b/ftx/api.py
@@ -6,6 +6,8 @@ from typing import Optional, Dict, Any, List
 from ciso8601 import parse_datetime
 from requests import Request, Session, Response
 
+from ftx.wsapi import FtxWebSocketClient
+
 
 class FtxClient:
     def __init__(
@@ -20,6 +22,7 @@ class FtxClient:
         self._api_key = api_key
         self._api_secret = api_secret
         self._subaccount_name = subaccount_name
+        self._ws_client = None
 
     def _get(self, path: str, params: Optional[Dict[str, Any]] = None) -> Any:
         return self._request('GET', path, params=params)
@@ -55,6 +58,21 @@ class FtxClient:
         if self._subaccount_name:
             request.headers['FTX-SUBACCOUNT'] = urllib.parse.quote(
                 self._subaccount_name)
+
+    @property
+    def websockets(self) -> FtxWebSocketClient:
+        """
+        Lazy FtxWebSocketClient with the same credentials
+
+        :return: FtxWebSocketClient
+        """
+        if not self._ws_client:
+            self._ws_client = FtxWebSocketClient(
+                api_key=self._api_key,
+                api_secret=self._api_secret,
+                subaccount_name=self._subaccount_name
+            )
+        return self._ws_client
 
     @staticmethod
     def _process_response(response: Response) -> Any:

--- a/ftx/fifo.py
+++ b/ftx/fifo.py
@@ -1,0 +1,20 @@
+import asyncio as asyncio
+
+
+class AsyncFifoQueue(asyncio.Queue):
+    def __init__(self, *args, **kwargs):
+        self._queue = None
+        self.items_dropped = 0
+        super().__init__(*args, **kwargs)
+
+    async def put(self, item) -> None:
+        if self.full():
+            self.items_dropped += 1
+            self._queue.pop()
+        await super().put(item)
+
+    def put_nowait(self, item) -> None:
+        if self.full():
+            self.items_dropped += 1
+            self._queue.pop()
+        super().put_nowait(item)

--- a/ftx/fifo.py
+++ b/ftx/fifo.py
@@ -2,6 +2,9 @@ import asyncio as asyncio
 
 
 class AsyncFifoQueue(asyncio.Queue):
+    """
+    FIFO Queue that counts the dropped items
+    """
     def __init__(self, *args, **kwargs):
         self._queue = None
         self.items_dropped = 0

--- a/ftx/wsapi.py
+++ b/ftx/wsapi.py
@@ -123,10 +123,9 @@ class FtxWebSocketClient:
                     self._on_message(json.loads(msg))
                 except JSONDecodeError:
                     print('could not parse JSON', msg)
-            except websockets.ConnectionClosedOK:
+            except:
                 self._ws = None
-            except Exception:
-                self._ws = None
+                self._queue.put_nowait(None)
                 print('websocket closed with error')
                 traceback.print_exc()
 
@@ -165,9 +164,12 @@ class FtxWebSocketClient:
 
     async def recv(self):
         """
-        Receives a single message from the websocket or waits until one is available
+        Receives a single message from the websocket or waits until one is available.
+        `None` is returned when the websocket is closed or closing.
 
         :return: a message dict
         """
+        if not self.connected:
+            return None
         return await self._queue.get()
 

--- a/ftx/wsapi.py
+++ b/ftx/wsapi.py
@@ -102,10 +102,10 @@ class FtxWebSocketClient:
 
     async def _ping_loop_fn(self):
         """
-        Ping keep-alive loop
+        Ping keep-alive loop, sends a ping message every 15 seconds
         """
         await asyncio.sleep(1)
-        while self._ws.open:
+        while self.connected:
             if not self._last_ping:
                 self._log('ping')
             self._last_ping = time.time()
@@ -125,7 +125,7 @@ class FtxWebSocketClient:
                     print('could not parse JSON', msg)
             except websockets.ConnectionClosedOK:
                 self._ws = None
-            except websockets.ConnectionClosedError:
+            except Exception:
                 self._ws = None
                 print('websocket closed with error')
                 traceback.print_exc()

--- a/ftx/wsapi.py
+++ b/ftx/wsapi.py
@@ -1,0 +1,143 @@
+import asyncio
+import hmac
+import json
+import time
+from typing import Optional
+
+import websockets
+from websockets.legacy.client import WebSocketClientProtocol
+
+
+class FtxWebSocketClient:
+    """
+    Basic FTX WebSocket client
+
+    See: https://docs.ftx.com/#websocket-api
+    """
+    _ws: Optional[WebSocketClientProtocol]
+
+    def __init__(self,
+                 api_key: Optional[str] = None,
+                 api_secret: Optional[str] = None,
+                 subaccount_name: Optional[str] = None,
+                 socket_url='wss://ftx.com/ws',
+                 verbose=False):
+        """
+        Create a websocket client
+
+        :param verbose: set to True to log messages and connection status
+        """
+        self._api_key = api_key
+        self._api_secret = api_secret
+        self._subaccount_name = subaccount_name
+        self._ws = None
+        self._last_ping = None
+        self.verbose = verbose
+        self.socket_url = socket_url
+        self._queue = asyncio.Queue(maxsize=0)
+
+    async def connect(self):
+        """
+        Connect to the websocket
+        :return:
+        """
+        self._ws = await websockets.connect(self.socket_url)
+        self._log('websocket connected')
+        asyncio.create_task(self._loop_fn())
+        asyncio.create_task(self._ping_loop_fn())
+
+    @property
+    def connected(self):
+        """
+        True if the websocket is connected and open
+        """
+        return self._ws and self._ws.open
+
+    def _log(self, *args, **kwargs):
+        if self.verbose:
+            print(*args, **kwargs)
+
+    def _on_message(self, msg):
+        if msg and 'type' in msg:
+            if msg['type'] != 'pong':
+                self._queue.put_nowait(msg)
+            else:
+                dt = time.time() - self._last_ping
+                self._log(f'pong ({round(dt, 2)}s)')
+
+    async def send_message(self, msg):
+        """
+        Send a message on the websocket
+
+        Example:
+            ``client.send_message({'op': 'ping'})``
+
+        :param msg: the message
+        """
+        self._log('->', msg)
+        await self._ws.send(json.dumps(msg))
+
+    async def _ping_loop_fn(self):
+        """
+        Ping keep-alive loop
+        """
+        await asyncio.sleep(1)
+        while self._ws.open:
+            if not self._last_ping:
+                self._log('ping')
+            self._last_ping = time.time()
+            await self.send_message({'op': 'ping'})
+            await asyncio.sleep(15)
+
+    async def _loop_fn(self):
+        """
+        Main message loop
+        """
+        while self._ws.open:
+            msg = await self._ws.recv()
+            try:
+                self._on_message(json.loads(msg))
+            except:
+                print('could not parse JSON', msg)
+
+    async def login(self):
+        assert self._api_key and self._api_secret, 'api_key and api_secret must be set to use login()'
+        ts = int(time.time() * 1000)
+        sign = hmac.new(self._api_secret.encode(), f'{ts}websocket_login', 'sha256').hexdigest()
+        msg = {'op': 'login', 'args': {'key': self._api_key, 'sign': sign, 'time': ts}}
+        await self.send_message(msg)
+
+    async def subscribe(self, channel: str, market: str):
+        """
+        Subscribe to a channel and market
+
+        :param channel: the channel
+        :param market: the market
+        """
+        await self.send_message({
+            'op': 'subscribe',
+            'channel': channel,
+            'market': market
+        })
+
+    async def unsubscribe(self, channel: str, market: str):
+        """
+        Unsubscribe from a channel and market
+
+        :param channel: the channel
+        :param market: the market
+        """
+        await self.send_message({
+            'op': 'unsubscribe',
+            'channel': channel,
+            'market': market
+        })
+
+    async def recv(self):
+        """
+        Receives a single message from the websocket or waits until one is available
+
+        :return: a message dict
+        """
+        return await self._queue.get()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ciso8601
 requests
+websockets


### PR DESCRIPTION
This PR adds a websocket client that handles the background ping messages and publishes other messages on a public queue.

Basic usage:
```python
async def main():
    ftx = FtxClient()
    # connect the websocket
    await ftx.websocket.connect()

    first_market = ftx.get_markets()[0]
    # subscribe to the trades channel of first available market
    await ftx.websocket.subscribe('trades', first_market['name'])

    while ftx.websocket.connected:
        # block and wait for next message from the queue
        msg = await ftx.websocket.recv()
        if 'channel' in msg and msg['channel'] == 'trades':
            if 'data' in msg:
                # print trade
                print(msg['market'], msg['data'][0]['side'], msg['data'][0]['size'])```