### PR TITLE
Argument in TakeProfit as limit order missing

### DIFF
--- a/ftx/api.py
+++ b/ftx/api.py
@@ -197,6 +197,7 @@ class FtxClient:
                                 limit_price: Optional[float] = None,
                                 reduce_only: bool = False,
                                 trigger_price: Optional[float] = None,
+                                orderPrice:    Optional[float] = None,
                                 trail_value: Optional[float] = None,
                                 retry_until_filled: Optional[bool] = None,
                                 ) -> dict:


### PR DESCRIPTION
orderPrice argument was missing in the place_conditional_order. so every time it was placing TP as market order