### PR TITLE
Replace websockets library with websocket-client for support proxy.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ciso8601
 requests
-websockets
+websocket-client

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author_email='thomgabriel@protonmail.com',
     url='https://github.com/quan-digital/ftx/tree/v1.2',
     download_url='https://github.com/quan-digital/ftx/archive/v1.2.tar.gz',
-    install_requires=['requests', 'ciso8601'],
+    install_requires=['requests', 'ciso8601', 'websocket-client'],
     packages=find_packages(),
     keywords=[
         'ftx', 'bitcoin', 'crypto-api', 'api-connector', 'exchange-api',


### PR DESCRIPTION
Because websockets library do not support proxy but websocket-client works perfect.

And I honestly find the fact that the issue for proxy support of websockets (https://github.com/aaugustin/websockets/issues/364) has been open for 3 years and has a "funding needed" label. That's amazing me.